### PR TITLE
feat!: make plugin handle any arbitrary filter

### DIFF
--- a/lua/buffed.lua
+++ b/lua/buffed.lua
@@ -7,16 +7,15 @@ local opt = vim.opt
 ---@class buffed
 local M = {}
 
----get file names for all buffs
----@return table<string>
-M.buffs = function()
-  return status.named "buff"
-end
 
----get file names for all debuffs
----@return table<string>
-M.debuffs = function()
-  return status.named "debuff"
+---get files of named filter
+---@return table<string>?
+M.get = function(name)
+  local filter = config.options.filters[name]
+  if filter then
+    return status.named(filter.fun)
+  end
+  return nil
 end
 
 ---@param opts buffed.options

--- a/lua/buffed.lua
+++ b/lua/buffed.lua
@@ -24,7 +24,13 @@ M.setup = function(opts)
     require "buffed.autocmds"
   end
   config.extend_options(opts)
-  highlights.create_hl_groups()
+
+  local user_defined_hls = {}
+  for _, filter in pairs(config.options.filters) do
+    table.insert(user_defined_hls, filter.hl)
+  end
+
+  highlights.create_hl_groups(user_defined_hls)
   opt.showtabline = 2
   opt.tabline = "%!v:lua.require'buffed.tabline'.show()"
 end

--- a/lua/buffed/config.lua
+++ b/lua/buffed/config.lua
@@ -6,28 +6,16 @@ local M = {}
 ---@field dynamic_tabline boolean: hides tabline when no buffer info available
 ---@field file_icons boolean
 ---@field ignore_current boolean: don't show tabline info for current open buffer
----@field buff Buff
----@field debuff Debuff
+---@class buffed.filter
+---@field icon string?
+---@field hl string?
+---@field fun function
+---@field filters table<string, buffed.filter>
 M.options = {
   dynamic_tabline = true,
   file_icons = true,
   ignore_current = true,
-  ---@class Buff
-  ---@field enabled boolean
-  ---@field icon string
-  buff = {
-    enabled = true,
-    icon = "",
-  },
-  ---@class Debuff
-  ---@field enabled boolean
-  ---@field icon string
-  ---@field severity "ERROR" | "WARN" | "INFO" | "HINT": minimal level required to be marked as debuff
-  debuff = {
-    enabled = true,
-    icon = "󰈸",
-    severity = "ERROR",
-  },
+  filters = {},
 }
 
 ---@param opts buffed.options

--- a/lua/buffed/constants.lua
+++ b/lua/buffed/constants.lua
@@ -6,28 +6,28 @@ local M = {}
 ---@field TabLine string
 ---@field TabLineFill string
 ---@field TabLineSel string
----@field BuffedMiniIconsAzure string
----@field BuffedMiniIconsBlue string
----@field BuffedMiniIconsCyan string
----@field BuffedMiniIconsGreen string
----@field BuffedMiniIconsGrey string
----@field BuffedMiniIconsOrange string
----@field BuffedMiniIconsPurple string
----@field BuffedMiniIconsRed string
----@field BuffedMiniIconsYellow string
+---@field MiniIconsAzure string
+---@field MiniIconsBlue string
+---@field MiniIconsCyan string
+---@field MiniIconsGreen string
+---@field MiniIconsGrey string
+---@field MiniIconsOrange string
+---@field MiniIconsPurple string
+---@field MiniIconsRed string
+---@field MiniIconsYellow string
 M.highlights = {
   TabLine = "TabLine",
   TabLineFill = "TabLineFill",
   TabLineSel = "TabLineSel",
-  BuffedMiniIconsAzure = "BuffedMiniIconsAzure",
-  BuffedMiniIconsBlue = "BuffedMiniIconsBlue",
-  BuffedMiniIconsCyan = "BuffedMiniIconsCyan",
-  BuffedMiniIconsGreen = "BuffedMiniIconsGreen",
-  BuffedMiniIconsGrey = "BuffedMiniIconsGrey",
-  BuffedMiniIconsOrange = "BuffedMiniIconsOrange",
-  BuffedMiniIconsPurple = "BuffedMiniIconsPurple",
-  BuffedMiniIconsRed = "BuffedMiniIconsRed",
-  BuffedMiniIconsYellow = "BuffedMiniIconsYellow",
+  MiniIconsAzure = "MiniIconsAzure",
+  MiniIconsBlue = "MiniIconsBlue",
+  MiniIconsCyan = "MiniIconsCyan",
+  MiniIconsGreen = "MiniIconsGreen",
+  MiniIconsGrey = "MiniIconsGrey",
+  MiniIconsOrange = "MiniIconsOrange",
+  MiniIconsPurple = "MiniIconsPurple",
+  MiniIconsRed = "MiniIconsRed",
+  MiniIconsYellow = "MiniIconsYellow",
 }
 
 return M

--- a/lua/buffed/constants.lua
+++ b/lua/buffed/constants.lua
@@ -2,24 +2,10 @@
 ---@class buffed.constants
 local M = {}
 
----@class buffed.severity
----@field ERROR integer
----@field WARN integer
----@field INFO integer
----@field HINT integer
-M.severity = {
-  ERROR = vim.diagnostic.severity.ERROR,
-  WARN = vim.diagnostic.severity.WARN,
-  INFO = vim.diagnostic.severity.INFO,
-  HINT = vim.diagnostic.severity.HINT,
-}
-
 ---@class buffed.highlights
 ---@field TabLine string
 ---@field TabLineFill string
 ---@field TabLineSel string
----@field BuffedBuff string
----@field BuffedDebuff string
 ---@field BuffedMiniIconsAzure string
 ---@field BuffedMiniIconsBlue string
 ---@field BuffedMiniIconsCyan string
@@ -33,8 +19,6 @@ M.highlights = {
   TabLine = "TabLine",
   TabLineFill = "TabLineFill",
   TabLineSel = "TabLineSel",
-  BuffedBuff = "BuffedBuff",
-  BuffedDebuff = "BuffedDebuff",
   BuffedMiniIconsAzure = "BuffedMiniIconsAzure",
   BuffedMiniIconsBlue = "BuffedMiniIconsBlue",
   BuffedMiniIconsCyan = "BuffedMiniIconsCyan",

--- a/lua/buffed/highlights.lua
+++ b/lua/buffed/highlights.lua
@@ -9,22 +9,22 @@ local M = {}
 ---@param group string
 ---@param attr string
 ---@return string
-local function get_color(group, attr)
+M.get_color = function(group, attr)
   return fn.synIDattr(fn.synIDtrans(fn.hlID(group)), attr)
 end
 
 ---@param bg string
 local set_icon_colors = function(bg)
   local icon_colors = {
-    [constants.highlights.BuffedMiniIconsAzure] = { fg = get_color("MiniIconsAzure", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsBlue] = { fg = get_color("MiniIconsBlue", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsCyan] = { fg = get_color("MiniIconsCyan", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsGreen] = { fg = get_color("MiniIconsGreen", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsGrey] = { fg = get_color("MiniIconsGrey", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsOrange] = { fg = get_color("MiniIconsOrange", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsPurple] = { fg = get_color("MiniIconsPurple", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsRed] = { fg = get_color("MiniIconsRed", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsYellow] = { fg = get_color("MiniIconsYellow", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsAzure] = { fg = M.get_color("MiniIconsAzure", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsBlue] = { fg = M.get_color("MiniIconsBlue", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsCyan] = { fg = M.get_color("MiniIconsCyan", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsGreen] = { fg = M.get_color("MiniIconsGreen", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsGrey] = { fg = M.get_color("MiniIconsGrey", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsOrange] = { fg = M.get_color("MiniIconsOrange", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsPurple] = { fg = M.get_color("MiniIconsPurple", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsRed] = { fg = M.get_color("MiniIconsRed", "fg#"), bg = bg },
+    [constants.highlights.BuffedMiniIconsYellow] = { fg = M.get_color("MiniIconsYellow", "fg#"), bg = bg },
   }
   for hl_key, hl_group in pairs(icon_colors) do
     api.nvim_set_hl(0, hl_key, hl_group)
@@ -34,10 +34,8 @@ end
 ---create custom highlight groups
 ---@return nil
 M.create_hl_groups = function()
-  local bg = get_color("TabLine", "bg#")
+  local bg = M.get_color("TabLine", "bg#")
   set_icon_colors(bg)
-  api.nvim_set_hl(0, constants.highlights.BuffedBuff, { fg = get_color("DiagnosticWarn", "fg#"), bg = bg })
-  api.nvim_set_hl(0, constants.highlights.BuffedDebuff, { fg = get_color("DiagnosticError", "fg#"), bg = bg })
 end
 
 return M

--- a/lua/buffed/highlights.lua
+++ b/lua/buffed/highlights.lua
@@ -9,33 +9,19 @@ local M = {}
 ---@param group string
 ---@param attr string
 ---@return string
-M.get_color = function(group, attr)
+local get_color = function(group, attr)
   return fn.synIDattr(fn.synIDtrans(fn.hlID(group)), attr)
 end
 
----@param bg string
-local set_icon_colors = function(bg)
-  local icon_colors = {
-    [constants.highlights.BuffedMiniIconsAzure] = { fg = M.get_color("MiniIconsAzure", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsBlue] = { fg = M.get_color("MiniIconsBlue", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsCyan] = { fg = M.get_color("MiniIconsCyan", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsGreen] = { fg = M.get_color("MiniIconsGreen", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsGrey] = { fg = M.get_color("MiniIconsGrey", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsOrange] = { fg = M.get_color("MiniIconsOrange", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsPurple] = { fg = M.get_color("MiniIconsPurple", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsRed] = { fg = M.get_color("MiniIconsRed", "fg#"), bg = bg },
-    [constants.highlights.BuffedMiniIconsYellow] = { fg = M.get_color("MiniIconsYellow", "fg#"), bg = bg },
-  }
-  for hl_key, hl_group in pairs(icon_colors) do
-    api.nvim_set_hl(0, hl_key, hl_group)
-  end
-end
-
 ---create custom highlight groups
+---@param filter_highlights table<string>
 ---@return nil
-M.create_hl_groups = function()
-  local bg = M.get_color("TabLine", "bg#")
-  set_icon_colors(bg)
+M.create_hl_groups = function(filter_highlights)
+  local bg = get_color("TabLine", "bg#")
+  local highlights = vim.tbl_extend("force", constants.highlights, filter_highlights)
+  for _, hl in pairs(highlights) do
+    api.nvim_set_hl(0, "Buffed" .. hl, { fg = get_color(hl, "fg#"), bg = bg })
+  end
 end
 
 return M

--- a/lua/buffed/integrations.lua
+++ b/lua/buffed/integrations.lua
@@ -2,54 +2,29 @@
 local M = {}
 
 ---opens a fzf-lua picker with buffs
+---@param filter string
 ---@param prompt string?
-M.fzf_buff = function(prompt)
+M.fzf = function(filter, prompt)
   prompt = prompt or "Buffs> "
-  require("fzf-lua").fzf_exec(require("buffed").buffs(), {
+  require("fzf-lua").fzf_exec(require("buffed").get(filter), {
     prompt = prompt,
     actions = {
-      ['default'] = require'fzf-lua'.actions.file_edit,
-    }
-  })
-end
-
----opens a fzf-lua picker with debuffs
----@param prompt string?
-M.fzf_debuff = function(prompt)
-  prompt = prompt or "Debuffs> "
-  require("fzf-lua").fzf_exec(require("buffed").debuffs(), {
-    prompt = prompt,
-    actions = {
-      ['default'] = require'fzf-lua'.actions.file_edit,
-    }
+      ["default"] = require("fzf-lua").actions.file_edit,
+    },
   })
 end
 
 ---opens a telescope picker with buffs
----@param opts table
+---@param filter string
+---@param opts table?
 ---@param prompt string?
-M.telescope_buff = function(opts, prompt)
+M.telescope_buff = function(filter, opts, prompt)
   opts = opts or {}
   prompt = prompt or "Buffs"
   require("telescope.pickers")
     .new(opts, {
       prompt_title = prompt,
-      finder = require("telescope.finders").new_table(require("buffed").buffs()),
-      sorter = require("telescope.config").generic_sorter(opts),
-    })
-    :find()
-end
-
----opens a telescope picker with debuffs
----@param opts table
----@param prompt string?
-M.telescope_debuff = function(opts, prompt)
-  opts = opts or {}
-  prompt = prompt or "Debuffs"
-  require("telescope.pickers")
-    .new(opts, {
-      prompt_title = prompt,
-      finder = require("telescope.finders").new_table(require("buffed").debuffs()),
+      finder = require("telescope.finders").new_table(require("buffed").get(filter)),
       sorter = require("telescope.config").generic_sorter(opts),
     })
     :find()

--- a/lua/buffed/status.lua
+++ b/lua/buffed/status.lua
@@ -1,12 +1,29 @@
 local options = require("buffed.config").options
 local utils = require "buffed.utils"
-local constants = require "buffed.constants"
 local api = vim.api
 local fn = vim.fn
 
 ---@private
 ---@class buffed.status
 local M = {}
+
+---get all loaded buffers excluding the currenlty open one
+---@return table<number>
+local get_buffers = function()
+  local current_buf = api.nvim_get_current_buf()
+  return vim.tbl_filter(function(bufnr)
+    return api.nvim_buf_is_loaded(bufnr) and (not options.ignore_current or bufnr ~= current_buf)
+  end, api.nvim_list_bufs())
+end
+
+---apply a filter to the buffers
+---@param filter_callback function
+---@return table<number>
+local filter = function(filter_callback)
+  return vim.tbl_filter(function(bufnr)
+    return filter_callback(bufnr)
+  end, get_buffers())
+end
 
 ---get a table of buffer file names by their ids
 ---@param buffers table<number>
@@ -24,47 +41,10 @@ local named_buffers = function(buffers)
   return named
 end
 
-local get_buffers = function()
-  local current_buf = api.nvim_get_current_buf()
-  return vim.tbl_filter(function(bufnr)
-    return api.nvim_buf_is_loaded(bufnr) and (not options.ignore_current or bufnr ~= current_buf)
-  end, api.nvim_list_bufs())
-end
-
----returns table of buffer id's that is modified
----@return table<number>
-local buffs = function()
-  local buffs = {}
-  for _, i in pairs(get_buffers()) do
-    if fn.getbufvar(i, "&mod") == 1 then
-      table.insert(buffs, i)
-    end
-  end
-  return buffs
-end
-
----returns table of buffer id's that are open and has diagnostic of configured level
----@return table<number>
-local debuffs = function()
-  local debuffs = {}
-  for _, i in pairs(get_buffers()) do
-    local diagnostic = vim.diagnostic.get(i, { severity = { min = constants.severity[options.debuff.severity] } })
-    if #diagnostic > 0 then
-      table.insert(debuffs, i)
-    end
-  end
-  return debuffs
-end
-
----get buffer names for either debuffs or buffs
----@param type "buff" | "debuff"
+---get buffer names for specified filter callback
+---@param callback function
 ---@return table<string>
-M.named = function(type)
-  if type == "buff" then
-    return named_buffers(buffs())
-  elseif type == "debuff" then
-    return named_buffers(debuffs())
-  end
-  return {}
+M.named = function(callback)
+    return named_buffers(filter(callback))
 end
 return M

--- a/lua/buffed/status.lua
+++ b/lua/buffed/status.lua
@@ -1,4 +1,4 @@
-local options = require("buffed.config").options
+local config = require("buffed.config")
 local utils = require "buffed.utils"
 local api = vim.api
 local fn = vim.fn
@@ -12,7 +12,7 @@ local M = {}
 local get_buffers = function()
   local current_buf = api.nvim_get_current_buf()
   return vim.tbl_filter(function(bufnr)
-    return api.nvim_buf_is_loaded(bufnr) and (not options.ignore_current or bufnr ~= current_buf)
+    return api.nvim_buf_is_loaded(bufnr) and (not config.options.ignore_current or bufnr ~= current_buf)
   end, api.nvim_list_bufs())
 end
 

--- a/lua/buffed/tabline.lua
+++ b/lua/buffed/tabline.lua
@@ -1,7 +1,7 @@
 local utils = require "buffed.utils"
 local constants = require "buffed.constants"
 local status = require "buffed.status"
-local options = require("buffed.config").options
+local config = require "buffed.config"
 
 local opt = vim.opt
 
@@ -14,7 +14,7 @@ local M = {}
 ---@return string?
 ---@return string?
 local get_icon = function(filename)
-  if not options.file_icons then
+  if not config.options.file_icons then
     return
   end
   local get = function()
@@ -22,7 +22,7 @@ local get_icon = function(filename)
   end
   local ok, icon, hl = pcall(get)
   if ok then
-    return icon, "Buffed" .. hl
+    return icon, hl
   end
 end
 
@@ -34,7 +34,7 @@ local get_title = function(bufname)
   local icon, hl = get_icon(filename)
   local fileicon = ""
   if icon and hl then
-    fileicon = utils._colorize(icon, hl) .. utils._spacer(0)
+    fileicon = utils._colorize(icon, "Buffed" .. hl) .. utils._spacer(0)
   end
   return fileicon .. utils._colorize(filename, constants.highlights.TabLine)
 end
@@ -50,7 +50,7 @@ local append = function(buffers, icon, hl)
     local filename = get_title(filepath)
     local colorized_icon = ""
     if icon then
-      colorized_icon = utils._colorize(icon, hl or constants.highlights.TabLine)
+      colorized_icon = utils._colorize(icon, "Buffed" .. hl or constants.highlights.TabLine)
     end
     s = s .. filename .. colorized_icon .. utils._spacer(2)
   end
@@ -62,12 +62,12 @@ end
 M.show = function()
   local s = ""
   local keys = {}
-  for key in pairs(options.filters) do
+  for key in pairs(config.options.filters) do
     table.insert(keys, key)
   end
 
   for i, key in ipairs(keys) do
-    local filter = options.filters[key]
+    local filter = config.options.filters[key]
     local buffers = status.named(filter.fun)
     if #buffers > 0 then
       s = s .. append(buffers, filter.icon, filter.hl)
@@ -77,7 +77,7 @@ M.show = function()
     end
   end
 
-  if options.dynamic_tabline and #s < 1 then
+  if config.options.dynamic_tabline and #s < 1 then
     opt.showtabline = 0
     return ""
   end


### PR DESCRIPTION
Resolves #1 

Example config for current behavior:

```lua
    opts = {
      filters = {
        modified = {
          icon = "",
          hl = "DiagnosticWarn",
          fun = function(bufnr)
            return vim.fn.getbufvar(bufnr, "&mod") == 1
          end,
        },
        with_error = {
          icon = "󰈸",
          hl = "DiagnosticError",
          fun = function(bufnr)
            local diagnostic = vim.diagnostic.get(bufnr, { severity = { min = "ERROR" } })
            return #diagnostic > 0
          end,
        },
      },
    },
    keys = {
      {
        "<leader>fb",
        function()
          vim.ui.select(require("buffed").get("modified"), { prompt = "select modifed" }, function(selection)
            vim.cmd.edit(selection)
          end)
        end,
        desc = "select buff",
      },
      {
        "<leader>fd",
        function()
          vim.ui.select(require("buffed").get("with_error"), { prompt = "select with error" }, function(selection)
            vim.cmd.edit(selection)
          end)
        end,
        desc = "select debuff",
      },
    },
```